### PR TITLE
Fixed colorimage binary image resizing problem

### DIFF
--- a/perception/image.py
+++ b/perception/image.py
@@ -1129,7 +1129,7 @@ class ColorImage(Image):
         :obj:`ColorImage`
             The resized image.
         """
-        resized_data = imresize(self.data, size, interp=interp).astype(np.uint8)
+        resized_data = (imresize(self.data, size, interp=interp)*255).astype(np.uint8)
         return ColorImage(resized_data, self._frame)
 
     def find_chessboard(self, sx=6, sy=9):


### PR DESCRIPTION
When trying to resize a uint8 color image, it seems like the resize function for binary images has broken. This results in a all zero image.
See: https://github.com/BerkeleyAutomation/perception/issues/20